### PR TITLE
[Refactor] 그룹 리스트 기능 중 유저 카운트관련 로직 rpc사용하여 최적화

### DIFF
--- a/src/app/grouplist/page.tsx
+++ b/src/app/grouplist/page.tsx
@@ -1,37 +1,10 @@
 import GroupList from '@/components/groupList/GroupList';
 import RandomImage from '@/components/groupList/RandomImage';
-import { getGroupPostLists } from '@/services/server-action/groupServerActions';
-import { createClient } from '@/utils/supabase/server';
-import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
 
 const GroupListPage = async () => {
-  // const queryClient = new QueryClient({
-  //   defaultOptions: {
-  //     queries: {
-  //       staleTime: 1000 * 60 * 10,
-  //     },
-  //   },
-  // });
-  // const supabase = createClient();
-  // const { data } = await supabase.auth.getUser();
-
-  // await queryClient.prefetchQuery({
-  //   queryKey: ['groupImages'],
-  //   queryFn: async () => {
-  //     let images = [];
-  //     if (data.user?.id) {
-  //       const userId = data.user.id;
-  //       const belongGroups = await getGroupPostLists(userId);
-  //       console.log('belongGroups :>> ', belongGroups);
-  //     }
-  //     return;
-  //   },
-  // });
   return (
     <div className='px-[16px] flex flex-col justify-center items-center'>
-      {/* <HydrationBoundary state={dehydrate(queryClient)}> */}
       <RandomImage />
-      {/* </HydrationBoundary> */}
       <GroupList />
     </div>
   );

--- a/src/components/groupList/GroupItem.tsx
+++ b/src/components/groupList/GroupItem.tsx
@@ -1,7 +1,7 @@
-import { GroupListResponseType } from '@/services/client-action/groupActions';
+import { GroupWithCounts } from '@/types/groupTypes';
 import { useRouter } from 'next/navigation';
 
-const GroupItem = ({ el }: { el?: GroupListResponseType }) => {
+const GroupItem = ({ el }: { el?: GroupWithCounts }) => {
   const router = useRouter();
   return (
     <li
@@ -9,12 +9,12 @@ const GroupItem = ({ el }: { el?: GroupListResponseType }) => {
       onClick={() => router.push(`/group/${el?.group_id}`)}
     >
       <img
-        src={el?.group_data.group_image_url}
-        alt={`${el?.group_data.group_title}_이미지`}
+        src={el?.group_image_url}
+        alt={`${el?.group_title}_이미지`}
         fetchPriority='high'
       />
       <div className='text-[14px] flex flex-row justify-between'>
-        <p className='max-w-[100px] truncate'>{el?.group_data.group_title}</p>
+        <p className='max-w-[100px] truncate'>{el?.group_title}</p>
         <p className='flex flex-row'>
           <span>
             <img
@@ -23,10 +23,10 @@ const GroupItem = ({ el }: { el?: GroupListResponseType }) => {
               className='w-[15px] h-[15px]'
             />
           </span>
-          <span>{el?.userCount}</span>
+          <span>{el?.user_count}</span>
         </p>
       </div>
-      <p>{el?.group_data.group_desc}</p>
+      <p>{el?.group_desc}</p>
     </li>
   );
 };

--- a/src/components/groupList/GroupList.tsx
+++ b/src/components/groupList/GroupList.tsx
@@ -27,7 +27,7 @@ const GroupList = () => {
           {FlattedData.map((el) => {
             return (
               <GroupItem
-                key={el?.id}
+                key={el?.group_id}
                 el={el}
               />
             );

--- a/src/components/groupList/RandomImage.tsx
+++ b/src/components/groupList/RandomImage.tsx
@@ -1,28 +1,10 @@
 'use client';
 
-import { getSignedImgUrl } from '@/services/server-action/getSignedImgUrl';
-import { getRandomGroupId, getRandomThumbnail } from '@/services/server-action/groupServerActions';
-import browserClient from '@/utils/supabase/client';
-import { useQuery } from '@tanstack/react-query';
+import { useGroupRandomImageQuery } from '@/hooks/queries/byUse/useGroupQueries';
 import { useEffect } from 'react';
 
 const RandomImage = () => {
-  const { data, isLoading, isPending, isError, refetch } = useQuery({
-    queryKey: ['groupImages'],
-    queryFn: async () => {
-      const { data } = await browserClient.auth.getUser();
-      let url = '';
-      if (data.user?.id) {
-        const userId = data.user.id;
-        const randomGroupData = await getRandomGroupId(userId);
-        if (randomGroupData) {
-          const thumbnailData = await getRandomThumbnail(randomGroupData);
-          if (thumbnailData) url = (await getSignedImgUrl('tour_images', 20, `/group_name/${thumbnailData}`)) as string;
-        }
-      }
-      return url;
-    },
-  });
+  const { data, isLoading, refetch } = useGroupRandomImageQuery();
   useEffect(() => {
     const refetchInterval = setInterval(() => {
       refetch();

--- a/src/services/groupServices.ts
+++ b/src/services/groupServices.ts
@@ -1,6 +1,5 @@
-import { getGroupUsersCount, GroupListResponseType } from './client-action/groupActions';
-import { getSignedImgUrl } from './server-action/getSignedImgUrl';
-import { GroupObjType, UserGroupType } from '@/types/groupTypes';
+import { getSignedImgUrls } from './server-action/getSignedImgUrls';
+import { GroupObjType, GroupWithCounts, UserGroupType } from '@/types/groupTypes';
 import { FieldValues } from 'react-hook-form';
 
 const makeGroupDataToObj = (value: FieldValues): GroupObjType => {
@@ -23,20 +22,9 @@ const makeUserGroupDataToObj = (userId: string, is_owner: boolean, group_id: str
   };
 };
 
-const getUserCount = async (groups: GroupListResponseType[]) => {
-  return await Promise.all(
-    groups.map(async (group) => {
-      return await getGroupUsersCount(group.group_data.group_id);
-    }),
-  );
+const getGroupSignedImageUrls = async (groups: GroupWithCounts[]) => {
+  const groupImages = groups.map((group) => group.group_image_url);
+  return await getSignedImgUrls('group_image', 1000 * 60 * 10, groupImages);
 };
 
-const getGroupSignedImageUrl = async (groups: GroupListResponseType[]) => {
-  return await Promise.all(
-    groups.map(async (group) => {
-      return await getSignedImgUrl('group_image', 1000 * 60 * 10, group.group_data.group_image_url);
-    }),
-  );
-};
-
-export { makeGroupDataToObj, makeUserGroupDataToObj, getUserCount, getGroupSignedImageUrl };
+export { makeGroupDataToObj, makeUserGroupDataToObj, getGroupSignedImageUrls };

--- a/src/services/server-action/getSignedImgUrls.ts
+++ b/src/services/server-action/getSignedImgUrls.ts
@@ -1,0 +1,15 @@
+'use server';
+
+import { createClient } from '@/utils/supabase/server';
+
+/**
+ * @function getSignedImgUrls = 여러 singedImgUrl을 한번에 받아올 수 있는 기능
+ * @param bucketName = 버킷 이름
+ * @param expiration = url유효기간 / 단위: 초
+ * @param imageNameArray = 저장된 이미지 이름 배열
+ * */
+export const getSignedImgUrls = async (bucketName: string, expiration: number, imageNameArray: string[]) => {
+  const supabase = createClient();
+  const { data: signedImgUrls } = await supabase.storage.from(bucketName).createSignedUrls(imageNameArray, expiration);
+  return signedImgUrls;
+};

--- a/src/types/groupTypes.ts
+++ b/src/types/groupTypes.ts
@@ -13,3 +13,12 @@ export type UserGroupType = {
   is_owner: boolean;
   joined_at: Date;
 };
+
+export type GroupWithCounts = {
+  group_desc: string;
+  group_id: string;
+  group_image_url: string;
+  group_title: string;
+  updated_at: Date;
+  user_count: number;
+};


### PR DESCRIPTION
## 🛂 연관된 커밋

> b44e88a1e543f991b248c40712d485b4f16e00ec

## #️⃣연관된 이슈

> #28 #27  

## 📝작업 내용

> supabase function 사용하여 그룹에 속한 유저 수 계산로직 간소화

### 스크린샷
![image](https://github.com/user-attachments/assets/50db86d8-fe78-4eed-89c4-5ff1deb14a6e)
- 기존 promise.all로 여러 요청을 나눠 사용하던 로직을 supabase function을 사용하여 6 => 1요청으로 간소화

## 💬리뷰 요구사항
> 아예 이미지를 signedUrl로 변환해서 보내줄 수 있으면 정말 좋을거같은데 방법을 모르겠습니다...