### PR TITLE
[Feat] 그룹 정보 수정 기능 추가

### DIFF
--- a/public/svgs/cameraIcon.svg
+++ b/public/svgs/cameraIcon.svg
@@ -1,0 +1,5 @@
+<svg width="27" height="18" viewBox="0 0 27 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" y="3.5" width="26" height="14" fill="#D9D9D9" stroke="black"/>
+<circle cx="13" cy="11" r="4.5" fill="#D9D9D9" stroke="black"/>
+<rect x="19.5" y="0.5" width="4" height="3" fill="#D9D9D9" stroke="black"/>
+</svg>

--- a/src/app/makegroup/page.tsx
+++ b/src/app/makegroup/page.tsx
@@ -1,32 +1,77 @@
 'use client';
 
 import { useMakeGroupForm } from '@/hooks/byUse/useGroupForm';
-import { useInsertGroupMutation, useInsertUserGroupMutation } from '@/hooks/queries/byUse/useGroupMutations';
-import { makeGroupDataToObj, makeUserGroupDataToObj } from '@/services/groupServices';
+import {
+  useInsertGroupMutation,
+  useInsertUserGroupMutation,
+  useUpdateGroupMutation,
+} from '@/hooks/queries/byUse/useGroupMutations';
+import { useGroupDetailQueryForUpdate } from '@/hooks/queries/byUse/useGroupQueries';
+import { makeGroupDataForUpdate, makeGroupDataToObj, makeUserGroupDataToObj } from '@/services/groupServices';
 import browserClient from '@/utils/supabase/client';
 import { useEffect, useState } from 'react';
 import { FieldValues } from 'react-hook-form';
 
-const MakeGroupPage = () => {
-  const { register, handleSubmit, formState, watch } = useMakeGroupForm();
+type Props = {
+  searchParams: { update_for?: string };
+};
+
+const MakeGroupPage = ({ searchParams: { update_for } }: Props) => {
+  const { register, handleSubmit, formState, watch, reset } = useMakeGroupForm();
   const [imgPreview, setImgPreview] = useState<string | null>(null);
 
   const { isError: insertGroupDataError, mutateAsync: insertGroupDataMutate } = useInsertGroupMutation();
   const { isError: insertUserGroupError, mutate: insertUserGroupMutate } = useInsertUserGroupMutation();
 
+  const { isError: updateGroupDataError, mutateAsync: updateGroupDataMutate } = useUpdateGroupMutation(update_for);
+
   const onSubmit = async (value: FieldValues) => {
     //TODO - 파일 확장자 관련 유효성 검사 필요
     const imageFile: File | null = value.groupImg && value?.groupImg[0];
-    const groupObj = makeGroupDataToObj(value);
-    await insertGroupDataMutate({ groupObj, groupImg: imageFile });
-    //TODO - user관련 store생성 후 userId 수정 필요
-    const { data } = await browserClient.auth.getUser();
-    if (data.user?.id) {
-      const userGroupObj = makeUserGroupDataToObj(data.user?.id, true, groupObj.group_id);
-      insertUserGroupMutate(userGroupObj);
+    if (update_for) {
+      const groupObj = makeGroupDataForUpdate(value, update_for);
+      await updateGroupDataMutate({ groupObj, groupImg: imageFile });
+    } else {
+      const groupObj = makeGroupDataToObj(value);
+      await insertGroupDataMutate({ groupObj, groupImg: imageFile });
+      //TODO - user관련 store생성 후 userId 수정 필요
+      const { data } = await browserClient.auth.getUser();
+      if (data.user?.id) {
+        const userGroupObj = makeUserGroupDataToObj(data.user?.id, true, groupObj.group_id);
+        insertUserGroupMutate(userGroupObj);
+      }
     }
   };
 
+  const urlToFileList = async (url: string) => {
+    const response = await fetch(url);
+    const blob = await response.blob();
+    const file = new File([blob], 'group_image.jpg', { type: blob.type });
+
+    // FileList 객체 생성
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(file);
+    return dataTransfer.files;
+  };
+
+  const { data: groupDetailData, isPending } = useGroupDetailQueryForUpdate(update_for);
+
+  useEffect(() => {
+    const fillGroupData = async () => {
+      if (groupDetailData && groupDetailData.group_image_url) {
+        const fileList = await urlToFileList(groupDetailData.group_image_url);
+        reset({
+          groupTitle: groupDetailData.group_title,
+          groupDesc: groupDetailData.group_desc,
+          groupImg: fileList as unknown as null,
+        });
+      }
+    };
+    fillGroupData();
+  }, [groupDetailData]);
+
+  const groupTitleLen = watch('groupTitle').length;
+  const groupDescLen = watch('groupDesc').length;
   const groupThumbnail = watch('groupImg') as FileList | null;
   useEffect(() => {
     if (groupThumbnail && groupThumbnail.length) {
@@ -34,62 +79,88 @@ const MakeGroupPage = () => {
     }
   }, [groupThumbnail]);
 
-  if (insertGroupDataError || insertUserGroupError) throw new Error('에러 발생!');
+  if (insertGroupDataError || insertUserGroupError || updateGroupDataError) throw new Error('에러 발생!');
   return (
-    <div className='flex flex-col justify-center items-center gap-[20px] my-[20px] py-[10px]'>
-      <form
-        onSubmit={handleSubmit(onSubmit)}
-        className='flex flex-col justify-center items-center gap-[30px]'
-      >
-        <div>
-          <label htmlFor='group_image'>
-            {imgPreview ? (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className='flex flex-col justify-center items-center gap-[30px]'
+    >
+      <div>
+        <label htmlFor='group_image'>
+          {imgPreview ? (
+            <div className='relative flex justify-center items-center w-[182px] h-[182px]'>
               <img
                 src={imgPreview}
                 alt='업로드 그룹 썸네일 이미지'
-                className='flex justify-center items-center rounded-[20px] w-[200px] h-[267px] border-[2px] border-black border-solid'
+                className='flex justify-center items-center w-[130px] h-[130px] border-[2px] border-black border-solid'
               />
-            ) : (
-              <div className='flex justify-center items-center rounded-[20px] px-[5px] w-[200px] h-[267px] bg-[#e6e6e6] border-[5px] border-black border-dashed'>
-                <p>그룹 이미지 첨부</p>
+              <div className='absolute bottom-0 right-0 w-[52px] h-[52px] flex justify-center items-center border border-solid border-black rounded-[26px] bg-white'>
+                <img
+                  src='/svgs/cameraIcon.svg'
+                  alt=''
+                />
               </div>
-            )}
-          </label>
-          <input
-            type='file'
-            id='group_image'
-            accept='image/*'
-            {...register('groupImg')}
-          />
-        </div>
-        <div className='p-[10px] border border-solid border-black w-[500px]'>
-          <label htmlFor='group_title'>그룹명</label>
+            </div>
+          ) : (
+            <div className='relative flex justify-center items-center w-[182px] h-[182px]'>
+              <img
+                className='w-[130px] h-[130px]'
+                src='/images/group_default_thumbnail.png'
+                alt=''
+              />
+              <div className='absolute bottom-0 right-0 w-[52px] h-[52px] flex justify-center items-center border border-solid border-black rounded-[26px] bg-white'>
+                <img
+                  src='/svgs/cameraIcon.svg'
+                  alt=''
+                />
+              </div>
+            </div>
+          )}
+        </label>
+        <input
+          type='file'
+          id='group_image'
+          accept='image/*'
+          className='hidden'
+          {...register('groupImg')}
+        />
+      </div>
+      <div className='p-[10px] flex flex-col justify-center gap-[3px]'>
+        <div className='h-[44px] flex flex-row items-center px-[5px] border-b border-solid border-black'>
           <input
             id='group_title'
+            className='w-[323px] text-[20px]'
             {...register('groupTitle')}
             type='text'
-            placeholder='그룹명'
+            placeholder='그룹 이름을 입력해주세요.'
+            maxLength={8}
           />
-          {formState.errors.groupTitle && <p>{formState.errors.groupTitle.message}</p>}
+          <p className='right-[6px] text-[#bdbdbd]'>{groupTitleLen}/8</p>
         </div>
-        <div className='p-[10px] border border-solid border-black w-[500px]'>
-          <label htmlFor='group_desc'>그룹상세내용</label>
-          <input
+        <p className='text-red-600 min-h-[20px] text-[14px]'>
+          {formState.errors.groupTitle && formState.errors.groupTitle.message}
+        </p>
+        <div className='relative flex justify-center'>
+          <textarea
             id='group_desc'
+            className='w-[343px] h-[169px] bg-[#bdbdbd] text-black text-[14px] py-[16px] px-[20px] placeholder:text-white resize-none'
             {...register('groupDesc')}
-            type='text'
-            placeholder='그룹정보'
+            placeholder='이 그룹에 대해서 설명해주세요.'
+            maxLength={40}
           />
-          {formState.errors.groupDesc && <p>{formState.errors.groupDesc.message}</p>}
+          <p className='absolute bottom-[9px] right-[16px] text-white'>{groupDescLen}/40</p>
         </div>
-        <button
-          className='cursor-pointer hover:bg-slate-300 p-[10px]'
-          type='submit'
-        >
-          그룹 생성
-        </button>
-      </form>
-    </div>
+        <p className='text-red-600 min-h-[20px] text-[14px]'>
+          {formState.errors.groupDesc && formState.errors.groupDesc.message}
+        </p>
+      </div>
+      <button
+        className='cursor-pointer bg-black text-white w-[343px] h-[56px] text-[20px]'
+        type='submit'
+      >
+        {update_for ? '수정 완료' : '그룹 만들기'}
+      </button>
+    </form>
   );
 };
 

--- a/src/hooks/queries/byUse/useGroupMutations.ts
+++ b/src/hooks/queries/byUse/useGroupMutations.ts
@@ -1,5 +1,5 @@
-import { insertGroupData, insertUserGroupData } from '@/services/client-action/groupActions';
-import { GroupObjType, UserGroupType } from '@/types/groupTypes';
+import { insertGroupData, insertUserGroupData, updateGroupData } from '@/services/client-action/groupActions';
+import { GroupObjType, UpdateGroupObjType, UserGroupType } from '@/types/groupTypes';
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 
@@ -15,6 +15,24 @@ type InsertGroupType = {
   groupObj: GroupObjType;
   groupImg: File | null;
 };
+
+type updateGroupType = {
+  groupObj: UpdateGroupObjType;
+  groupImg: File | null;
+};
+
+const useUpdateGroupMutation = (group_id?: string) => {
+  const router = useRouter();
+  return useMutation({
+    mutationFn: async ({ groupObj, groupImg }: updateGroupType) => await updateGroupData(groupObj, groupImg),
+    onSuccess: (data) => {
+      router.push(`/group/${group_id}`);
+      // console.log('data :>> ', data);
+    },
+    onError: (error) => console.log('error :>> ', error),
+  });
+};
+
 //TODO - invalidate필요시 쿼리키 추가 필요
 const useInsertGroupMutation = () => {
   return useMutation({
@@ -41,4 +59,4 @@ const useInsertUserGroupMutation = () => {
   });
 };
 
-export { useInsertGroupMutation, useInsertUserGroupMutation };
+export { useInsertGroupMutation, useUpdateGroupMutation, useInsertUserGroupMutation };

--- a/src/hooks/queries/byUse/useGroupQueries.ts
+++ b/src/hooks/queries/byUse/useGroupQueries.ts
@@ -5,6 +5,13 @@ import { GroupWithCounts } from '@/types/groupTypes';
 import browserClient from '@/utils/supabase/client';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 
+const useGroupDetailQueryForUpdate = (group_id?: string) => {
+  return useQuery({
+    queryKey: ['groupDetail', group_id],
+    queryFn: () => (group_id ? getGroupDetails(group_id) : null),
+  });
+};
+
 const useGroupDetailQuery = (group_id: string) => {
   return useQuery({
     queryKey: ['groupDetail', group_id],
@@ -67,4 +74,4 @@ const useGroupRandomImageQuery = () => {
   });
 };
 
-export { useGroupDetailQuery, useGroupListInfiniteQuery, useGroupRandomImageQuery };
+export { useGroupDetailQueryForUpdate, useGroupDetailQuery, useGroupListInfiniteQuery, useGroupRandomImageQuery };

--- a/src/schemas/groupSchemas.ts
+++ b/src/schemas/groupSchemas.ts
@@ -3,9 +3,9 @@ import { z } from 'zod';
 const groupSchema = z.object({
   groupTitle: z
     .string({ message: '그룹명을 입력해주세요!' })
-    .min(1, { message: '그룹명은 1글자 이상 10글자 이하여야 합니다.' })
-    .max(10, { message: '그룹명은 1글자 이상 10글자 이하여야 합니다.' }),
-  groupDesc: z.string(),
+    .min(1, { message: '그룹명은 1글자 이상 8글자 이하여야 합니다.' })
+    .max(8, { message: '그룹명은 1글자 이상 8글자 이하여야 합니다.' }),
+  groupDesc: z.string().max(40, { message: '그룹 설명은 40글자 이하여야 합니다.' }),
   //NOTE - 이미지 파일 관련 zod 유효성검사 처리가능한 방법 있는지 확인 필요
   groupImg: z.any(),
 });

--- a/src/services/client-action/groupActions.ts
+++ b/src/services/client-action/groupActions.ts
@@ -1,4 +1,4 @@
-import { GroupObjType, UserGroupType } from '@/types/groupTypes';
+import { GroupObjType, UpdateGroupObjType, UserGroupType } from '@/types/groupTypes';
 import browserClient from '@/utils/supabase/client';
 
 const uploadDefaultGroupImg = async (group_id: string) => {
@@ -13,6 +13,37 @@ const uploadDefaultGroupImg = async (group_id: string) => {
 const uploadGroupImg = async (groupImg: File, group_id: string) => {
   const { data, error } = await browserClient.storage.from('group_image').upload(`${group_id}_thumbnail`, groupImg);
   return { data, error };
+};
+
+const updateDefaultGroupImg = async (group_id: string) => {
+  const defaultImgRes = await fetch('/images/group_default_thumbnail.png');
+  const defaultImgBlob = await defaultImgRes.blob();
+  const { data, error } = await browserClient.storage
+    .from('group_image')
+    .upload(`${group_id}_thumbnail`, defaultImgBlob, {
+      upsert: true,
+    });
+  return { data, error };
+};
+const updateGroupImg = async (groupImg: File, group_id: string) => {
+  const { data, error } = await browserClient.storage.from('group_image').upload(`${group_id}_thumbnail`, groupImg, {
+    upsert: true,
+  });
+  return { data, error };
+};
+
+const updateGroupData = async (groupObj: UpdateGroupObjType, groupImg: File | null) => {
+  //NOTE - 그룹 이미지가 사라졌을 시 public의 기본썸네일 사용, 있을 시 업로드한 이미지 사용
+  if (!groupImg) {
+    const { data, error } = await updateDefaultGroupImg(groupObj.group_id);
+    if (error) throw error;
+  } else {
+    const { data, error } = await updateGroupImg(groupImg, groupObj.group_id);
+    if (error) throw error;
+  }
+  const updateState = await browserClient.from('group').update(groupObj).eq('group_id', groupObj.group_id);
+  if (updateState.status !== 204) throw updateState.error;
+  else if (updateState.status === 204) return { data: updateState.data, error: updateState.error };
 };
 
 const insertGroupData = async (groupObj: GroupObjType, groupImg: File | null) => {
@@ -85,4 +116,4 @@ const getGroupUsersCount = async (groupId: string) => {
   return state.data?.length;
 };
 
-export { insertGroupData, insertUserGroupData, getGroupListByPage, getGroupUsersCount };
+export { updateGroupData, insertGroupData, insertUserGroupData, getGroupListByPage, getGroupUsersCount };

--- a/src/services/groupServices.ts
+++ b/src/services/groupServices.ts
@@ -2,6 +2,14 @@ import { getSignedImgUrls } from './server-action/getSignedImgUrls';
 import { GroupObjType, GroupWithCounts, UserGroupType } from '@/types/groupTypes';
 import { FieldValues } from 'react-hook-form';
 
+const makeGroupDataForUpdate = (value: FieldValues, update_for: string) => {
+  return {
+    group_id: update_for,
+    updated_at: new Date(),
+    group_title: value.groupTitle,
+    group_desc: value.groupDesc,
+  };
+};
 const makeGroupDataToObj = (value: FieldValues): GroupObjType => {
   return {
     group_id: crypto.randomUUID(),
@@ -27,4 +35,4 @@ const getGroupSignedImageUrls = async (groups: GroupWithCounts[]) => {
   return await getSignedImgUrls('group_image', 1000 * 60 * 10, groupImages);
 };
 
-export { makeGroupDataToObj, makeUserGroupDataToObj, getGroupSignedImageUrls };
+export { makeGroupDataForUpdate, makeGroupDataToObj, makeUserGroupDataToObj, getGroupSignedImageUrls };

--- a/src/services/server-action/groupServerActions.ts
+++ b/src/services/server-action/groupServerActions.ts
@@ -49,8 +49,6 @@ const getRandomThumbnail = async (groupId: string) => {
   const { data, error } = await supabase.rpc('get_group_thumbnail_by_group_id', {
     input_group_id: groupId,
   });
-  //NOTE - 썸네일 이미지, created_at, post_address도 같이 가져와야함
-  //근데 어떻게 고쳐야할지 모르겠음
   if (data) return data as string;
   return null;
 };

--- a/src/types/groupTypes.ts
+++ b/src/types/groupTypes.ts
@@ -7,6 +7,13 @@ export type GroupObjType = {
   created_at: Date;
 };
 
+export type UpdateGroupObjType = {
+  group_id: string;
+  updated_at: Date;
+  group_title?: string;
+  group_desc?: string;
+};
+
 export type UserGroupType = {
   user_id: string;
   group_id: string;


### PR DESCRIPTION
## 🛂 연관된 커밋

> 0cc6a53491dc6ea017e6c94fccc3e3dfa306f65a

## #️⃣연관된 이슈
> 

## 📝작업 내용

> 그룹 정보 수정 기능 추가하였습니다.
> 그룹 생성페이지를 같이 사용하며 querystring의 update_for에 group_id를 입력해주면 수정기능으로 작동하게 됩니다.
> http://localhost:3000/makegroup?update_for=f0c7b577-c6be-4505-8032-5490903f9f54

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/ef6669da-12cd-4f5d-b7c9-22ee6539e9f0)

## 💬리뷰 요구사항(선택)

> 같은 페이지를 사용하려다보니 조금 코드가 길어지고 더러워지는데 분리하는게 좋을지 고민됩니다.
> update_for이 있을 시 첫 데이터 로딩에 시간이 조금 걸려 로딩상태에따라 화면에 로딩중이라는걸 보여줘야할것같습니다.
