### PR TITLE
[Style] 그룹생성버튼 Link태그로 변경, Link태그로 동작하는 LinkButton 공통컴포넌트 생성

### DIFF
--- a/src/components/groupList/GroupAddButton.tsx
+++ b/src/components/groupList/GroupAddButton.tsx
@@ -3,8 +3,10 @@
 import SubmitInviteForm from './SubmitInviteForm';
 import { useIsOpen } from '@/hooks/byUse/useIsOpen';
 import { Button } from '@/stories/Button';
+import { LinkButton } from '@/stories/LinkButton';
 import { Modal } from '@/stories/Modal';
 import { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 type Props = {
@@ -31,9 +33,9 @@ const AddButtons = ({ router, handleBottomSheetOpen }: AddButtonsProps) => {
           alt=''
         />
       </Button>
-      <Button
+      <LinkButton
         label='그룹만들기'
-        onClick={() => router.push('/makegroup')}
+        href='/makegroup'
         size='full'
         className='text-tile_lg text-white'
       >
@@ -41,7 +43,7 @@ const AddButtons = ({ router, handleBottomSheetOpen }: AddButtonsProps) => {
           src='/svgs/Plus_LG.svg'
           alt=''
         />
-      </Button>
+      </LinkButton>
     </>
   );
 };

--- a/src/stories/LinkButton.tsx
+++ b/src/stories/LinkButton.tsx
@@ -1,0 +1,89 @@
+import { cn } from '@/lib/utils';
+import Link from 'next/link';
+import React from 'react';
+
+export interface LinkButtonProps extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'type'> {
+  variant?: 'primary' | 'secondary' | 'outlinePink' | 'outlineGray';
+  size?: 'small' | 'medium' | 'large' | 'full';
+  loading?: boolean;
+  label?: string;
+  children?: React.ReactNode;
+  className?: string;
+  onClick?: () => void;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
+  onFocus?: () => void;
+  onBlur?: () => void;
+  href: string;
+}
+
+export const LinkButton = ({
+  variant = 'primary',
+  size = 'medium',
+  className,
+  onClick,
+  loading = false,
+  label,
+  children,
+  onMouseEnter,
+  onMouseLeave,
+  onFocus,
+  onBlur,
+  href,
+  ...props
+}: LinkButtonProps) => {
+  const baseStyle = 'inline-flex items-center justify-center focus:outline-none';
+  const sizeStyle = {
+    small: 'px-4 py-2 text-label_sm rounded-[4px]',
+    medium: 'px-5 py-3 text-label_md rounded-[8px]',
+    large: 'px-6 py-3 text-title_lg rounded-[12px]',
+    full: 'px-5 py-3 text-label_md rounded-[8px] w-full',
+  }[size];
+
+  let colorStyle;
+  let loadingStyle = 'cursor-not-allowed opacity-50';
+
+  switch (variant) {
+    case 'primary':
+      colorStyle = 'bg-primary-400 text-white hover:bg-primary-600';
+      loadingStyle = 'bg-primary-200 text-white hover:bg-primary-200 cursor-not-allowed';
+      break;
+    case 'secondary':
+      colorStyle = 'bg-secondary-100 text-black hover:bg-secondary-600';
+      loadingStyle = 'bg-secondary-100 text-gray-500 hover:bg-secondary-100 cursor-not-allowed';
+      break;
+    case 'outlinePink':
+      colorStyle = 'bg-white text-secondary-400 border border-secondary-400 hover:bg-secondary-50';
+      loadingStyle = 'bg-white text-secondary-50 border border-secondary-50 hover:bg-white cursor-not-allowed';
+      break;
+    case 'outlineGray':
+      colorStyle = 'bg-white text-gray-700 border border-gray-700 hover:bg-gray-100';
+      loadingStyle = 'bg-white text-gray-100 border border-gray-100 hover:bg-white cursor-not-allowed';
+      break;
+    default:
+      colorStyle = 'bg-transparent text-gray-700 border border-gray-300 hover:bg-gray-100';
+  }
+
+  return (
+    <Link
+      href={href}
+      className={cn(baseStyle, sizeStyle, colorStyle, { [loadingStyle]: loading }, className)}
+      onClick={onClick}
+      aria-label={props['aria-label']}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      {...props}
+    >
+      {loading ? (
+        '로딩 중...'
+      ) : (
+        <>
+          {children && <span className={cn('mr-2 flex items-center')}>{children}</span>}
+          {label}
+        </>
+      )}
+    </Link>
+  );
+};


### PR DESCRIPTION
## 🛂 연관된 커밋

> 9f046f361306e6084791fc225660ad332a1aafc0

## #️⃣연관된 이슈

> #122

## 📝작업 내용

> 그룹생성페이지 이동버튼 Link태그로 변경

## 💬리뷰 요구사항(선택)

> @yuna-c 유나님 공통 버튼 컴포넌트 스타일이나 props 그대로 사용했는데 LinkButton괜찮은지 한번 확인해주세요!
> 단순 이동버튼 역할이다보니 disabled는 필요없을것같아 삭제하였습니다
