### PR TITLE
fix : 상세에서 로고 클릭시 그룹 페이지로/글 길어지면 줄바꿈

### DIFF
--- a/src/app/group/[groupId]/post/[postId]/page.tsx
+++ b/src/app/group/[groupId]/post/[postId]/page.tsx
@@ -85,7 +85,7 @@ const TourDetail = async ({
   return (
     <div>
       <div className='relative mx-4 flex items-center py-4'>
-        <MyPageHeader url={URLS.groupList} />
+        <MyPageHeader url={`/group/${postData.group_id}`} />
         <span className='mx-auto text-label_md text-gray-900'>{groupDetail?.group_title}</span>
       </div>
       <PostDetail

--- a/src/components/myPage/MyPageHeader.tsx
+++ b/src/components/myPage/MyPageHeader.tsx
@@ -1,19 +1,20 @@
 'use client';
 
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import React from 'react';
-import Link from 'next/link';
 
 const MyPageHeader = ({ url }: { url: string }) => {
-  const router = useRouter();
   return (
-    <Link href={'./'} className='absolute left-0'>
-    <img
-      src='/svgs/Logo.svg'
-      alt='Image'
-      onClick={() => router.push(url)}
+    <Link
+      href={url}
+      className='absolute left-0'
+    >
+      <img
+        src='/svgs/Logo.svg'
+        alt='Image'
       />
-      </Link>
+    </Link>
   );
 };
 

--- a/src/components/post/postDetail/Comment.tsx
+++ b/src/components/post/postDetail/Comment.tsx
@@ -64,14 +64,14 @@ const Comment = ({
   return (
     <>
       {isEditMode ? (
-        <div className='flex flex-col py-4 gap-3 px-4'>
+        <div className='flex flex-col gap-3 px-4 py-4'>
           <form
             className='flex flex-col gap-2'
             onSubmit={handleUpdateComment}
           >
-            <div className='flex flex-col border rounded-[12px] py-2 px-3 gap-1 bg-white'>
-              <span className='text-gray-900 text-label_sm'>{userDetail?.profiles.user_nickname}</span>
-              <input
+            <div className='flex flex-col gap-1 rounded-[12px] border bg-white px-3 py-2'>
+              <span className='text-label_sm text-gray-900'>{userDetail?.profiles.user_nickname}</span>
+              <textarea
                 value={newCommentDesc}
                 onChange={(e) => {
                   setNewCommentDesc(e.target.value);
@@ -91,21 +91,21 @@ const Comment = ({
           </form>
         </div>
       ) : (
-        <div className='flex py-4 gap-3 px-4'>
+        <div className='flex gap-3 px-4 py-4'>
           <>
-            <div className='w-[32px] h-[32px] overflow-hidden rounded-full'>
+            <div className='h-[32px] w-[32px] overflow-hidden rounded-full'>
               <img
                 alt='프로필 이미지'
                 src={authorProfileData?.profileImageUrl || '/svgs/Profile.svg'} // 이 글을 쓴 사람
-                className='object-cover w-full h-full'
+                className='h-full w-full object-cover'
               />
             </div>
 
             {/* 댓글 부분 */}
             <div className='w-full pb-1'>
               {/* 닉네임 */}
-              <div className='flex justify-between '>
-                <span className='text-gray-900 text-label_sm'>{commentAuthor?.user_nickname}</span>
+              <div className='flex justify-between'>
+                <span className='text-label_sm text-gray-900'>{commentAuthor?.user_nickname}</span>
                 <CommentOptions
                   commentId={commentId}
                   setIsEditMode={setIsEditMode}
@@ -116,12 +116,12 @@ const Comment = ({
               </div>
               {/* 댓글 내용 */}
               <div className='flex justify-between pb-2'>
-                <p className='text-gray-900 text-body_sm'>{commentDesc}</p>
+                <p className='break-all text-body_sm text-gray-900'>{commentDesc}</p>
               </div>
               <div>
                 {parentId === null ? (
                   <span
-                    className='text-gray-500 text-caption_bold_md '
+                    className='text-caption_bold_md text-gray-500'
                     onClick={() => setIsWriteReplyMode && setIsWriteReplyMode(true)}
                   >
                     답글 쓰기

--- a/src/components/post/postDetail/CommentForm.tsx
+++ b/src/components/post/postDetail/CommentForm.tsx
@@ -37,14 +37,14 @@ const CommentForm = ({ postId, user, parentId, setIsWriteMode, setIsWriteReplyMo
   };
 
   return (
-    <div className='py-4 '>
+    <div className='px-4 py-4'>
       <form
         className='flex flex-col gap-2'
         onSubmit={handleSubmit}
       >
-        <div className='flex flex-col border rounded-[12px] py-2 px-3 gap-1 bg-white'>
-          <span className='text-gray-900 text-label_sm'>{user?.profiles.user_nickname}</span>
-          <input
+        <div className='flex flex-col gap-1 rounded-[12px] border bg-white px-3 py-2'>
+          <span className='text-label_sm text-gray-900'>{user?.profiles.user_nickname}</span>
+          <textarea
             value={comment}
             onChange={(e) => {
               setComment(e.target.value);

--- a/src/components/post/postDetail/PostDetail.tsx
+++ b/src/components/post/postDetail/PostDetail.tsx
@@ -58,7 +58,7 @@ const PostDetail = ({ postData, signedImageUrls, coverImageDate, userDetail, pos
           <span className='text-label_md text-gray-900'>{postAuthorDetail.profiles.user_nickname}</span>
         </div>
         <div>
-          <p className='text-body_md text-black'>{postData.post_desc}</p>
+          <p className='break-all text-body_md text-black'>{postData.post_desc}</p>
         </div>
         {/* 태그 영역 */}
         <div className='flex gap-1 px-4'>


### PR DESCRIPTION


## 🛂 연관된 커밋

> ex) 479eccefac604d886b67d10b524d639f1ef277ec

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

게시글 상세에서 로고 클릭시
수정페이지로 이동하는 문제 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
