### PR TITLE
[Refactor] 그룹 상세페이지 zustand 적용 및 마우스 호버 프리페치 적용

### DIFF
--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -6,6 +6,7 @@ import GroupMap from '@/components/map/GroupMap';
 import URLS from '@/constants/urls';
 import { useGroupDetailModeStore } from '@/hooks/groupDetail/useGroupDetailModeStore';
 import { useGroupInfoQuery } from '@/hooks/queries/byUse/useGroupQueries';
+import { getGroupPostsImagesPrefetchQuery } from '@/hooks/queries/post/useGroupPostsQuery';
 import { GroupDetailMode } from '@/types/groupTypes';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
@@ -16,6 +17,7 @@ type Props = Readonly<{ params: { groupId: string } }>;
 
 const GroupPage = ({ params: { groupId } }: Props) => {
   const { mode, toMap, toAlbum } = useGroupDetailModeStore((state) => state);
+  const prefetchGroupPostsImages = getGroupPostsImagesPrefetchQuery(groupId);
 
   const { data: groupInfo, isPending, isError, error } = useGroupInfoQuery(groupId);
 
@@ -28,7 +30,10 @@ const GroupPage = ({ params: { groupId } }: Props) => {
     switch (mode) {
       case GroupDetailMode.map:
         return (
-          <button onClick={toAlbum}>
+          <button
+            onClick={toAlbum}
+            onMouseEnter={prefetchGroupPostsImages}
+          >
             <img src='/svgs/Swap_Btn_To_Album.svg' />
           </button>
         );

--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -15,7 +15,7 @@ const ToastContainer = dynamic(() => import('@/components/toast/GarlicToast'), {
 type Props = Readonly<{ params: { groupId: string } }>;
 
 const GroupPage = ({ params: { groupId } }: Props) => {
-  const { mode, toMap, toAlbum, toMember } = useGroupDetailModeStore((state) => state);
+  const { mode, toMap, toAlbum } = useGroupDetailModeStore((state) => state);
 
   const { data: groupInfo, isPending, isError, error } = useGroupInfoQuery(groupId);
 

--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -4,19 +4,18 @@ import GroupAlbum from '@/components/groupAlbum/GroupAlbum';
 import MemberList from '@/components/groupAlbum/MemberList';
 import GroupMap from '@/components/map/GroupMap';
 import URLS from '@/constants/urls';
+import { useGroupDetailModeStore } from '@/hooks/groupDetail/useGroupDetailModeStore';
 import { useGroupInfoQuery } from '@/hooks/queries/byUse/useGroupQueries';
 import { GroupDetailMode } from '@/types/groupTypes';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
-import { useState } from 'react';
 
 const ToastContainer = dynamic(() => import('@/components/toast/GarlicToast'), { ssr: false });
 
 type Props = Readonly<{ params: { groupId: string } }>;
 
 const GroupPage = ({ params: { groupId } }: Props) => {
-  //TODO - zustand 관리
-  const [mode, setMode] = useState<GroupDetailMode>(GroupDetailMode.map);
+  const { mode, toMap, toAlbum, toMember } = useGroupDetailModeStore((state) => state);
 
   const { data: groupInfo, isPending, isError, error } = useGroupInfoQuery(groupId);
 
@@ -29,13 +28,13 @@ const GroupPage = ({ params: { groupId } }: Props) => {
     switch (mode) {
       case GroupDetailMode.map:
         return (
-          <button onClick={() => setMode(GroupDetailMode.album)}>
+          <button onClick={toAlbum}>
             <img src='/svgs/Swap_Btn_To_Album.svg' />
           </button>
         );
       case GroupDetailMode.album:
         return (
-          <button onClick={() => setMode(GroupDetailMode.map)}>
+          <button onClick={toMap}>
             <img src='/svgs/Swap_Btn_To_Map.svg' />
           </button>
         );
@@ -43,7 +42,7 @@ const GroupPage = ({ params: { groupId } }: Props) => {
         return (
           <button
             className='h-10 w-10'
-            onClick={() => setMode(GroupDetailMode.album)}
+            onClick={toAlbum}
           >
             <img
               className='mx-auto'
@@ -66,7 +65,6 @@ const GroupPage = ({ params: { groupId } }: Props) => {
           <GroupAlbum
             groupId={groupId}
             groupInfo={groupInfo}
-            setMode={setMode}
           />
         );
       case GroupDetailMode.member:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import { GroupDetailModeProvider } from '@/components/providers/GroupDetailModeProvider';
 import QueryProvider from '@/components/providers/QueryProvider';
 import '@/styles/globals.css';
-import { GroupDetailMode } from '@/types/groupTypes';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,7 @@
+import { GroupDetailModeProvider } from '@/components/providers/GroupDetailModeProvider';
 import QueryProvider from '@/components/providers/QueryProvider';
 import '@/styles/globals.css';
+import { GroupDetailMode } from '@/types/groupTypes';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -19,7 +21,9 @@ const RootLayout = ({
     >
       <body className={`font-sans`}>
         <QueryProvider>
-          <main className='w-full h-full'>{children}</main>
+          <GroupDetailModeProvider mode={GroupDetailMode.map}>
+            <main className='h-full w-full'>{children}</main>
+          </GroupDetailModeProvider>
         </QueryProvider>
       </body>
     </html>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,7 +21,7 @@ const RootLayout = ({
     >
       <body className={`font-sans`}>
         <QueryProvider>
-          <GroupDetailModeProvider mode={GroupDetailMode.map}>
+          <GroupDetailModeProvider>
             <main className='h-full w-full'>{children}</main>
           </GroupDetailModeProvider>
         </QueryProvider>

--- a/src/components/groupAlbum/GroupAlbum.tsx
+++ b/src/components/groupAlbum/GroupAlbum.tsx
@@ -3,16 +3,15 @@
 import GroupInfoBox from './GroupInfoBox';
 import useIntersect from '@/hooks/byUse/useIntersection';
 import { getGroupPostsImagesQuery } from '@/hooks/queries/post/useGroupPostsQuery';
-import { GroupDetailMode, type GroupInfo } from '@/types/groupTypes';
+import { GroupDetailModeState, type GroupInfo } from '@/types/groupTypes';
 import Link from 'next/link';
 
 type Props = {
   groupId: string;
   groupInfo: GroupInfo;
-  setMode: React.Dispatch<React.SetStateAction<GroupDetailMode>>;
 };
 
-const GroupAlbum = ({ groupId, groupInfo, setMode }: Props) => {
+const GroupAlbum = ({ groupId, groupInfo }: Props) => {
   const { data, isPending, isError, error, hasNextPage, fetchNextPage, isFetchingNextPage, isFetching } =
     getGroupPostsImagesQuery(groupId);
   const observerRef = useIntersect(async (entry, observer) => {
@@ -38,7 +37,6 @@ const GroupAlbum = ({ groupId, groupInfo, setMode }: Props) => {
       <GroupInfoBox
         groupId={groupId}
         groupInfo={groupInfo}
-        setMode={setMode}
       />
       {!!postsImages.length ? (
         <>

--- a/src/components/groupAlbum/GroupInfoBox.tsx
+++ b/src/components/groupAlbum/GroupInfoBox.tsx
@@ -1,15 +1,16 @@
 'use client';
 
-import { GroupDetailMode, type GroupInfo } from '@/types/groupTypes';
+import { useGroupDetailModeStore } from '@/hooks/groupDetail/useGroupDetailModeStore';
+import { type GroupInfo } from '@/types/groupTypes';
 import Link from 'next/link';
 
 type Props = {
   groupId: string;
   groupInfo: GroupInfo;
-  setMode: React.Dispatch<React.SetStateAction<GroupDetailMode>>;
 };
 
-const GroupInfoBox = ({ groupId, groupInfo: { group_image_url, user_group, group_desc }, setMode }: Props) => {
+const GroupInfoBox = ({ groupId, groupInfo: { group_image_url, user_group, group_desc } }: Props) => {
+  const { toMember } = useGroupDetailModeStore((state) => state);
   return (
     <div className='px-4'>
       <div className='flex flex-row gap-4 border-b py-6'>
@@ -20,7 +21,7 @@ const GroupInfoBox = ({ groupId, groupInfo: { group_image_url, user_group, group
         />
         <div className='flex w-full flex-col gap-3'>
           <div className='flex flex-row justify-between'>
-            <button onClick={() => setMode(GroupDetailMode.member)}>
+            <button onClick={toMember}>
               <div className='flex flex-row items-center gap-1 rounded-xl border border-gray-100 px-2 py-1'>
                 <img src='/svgs/Group_Member.svg' />
                 <p className='text-label_sm'>{user_group.length}</p>

--- a/src/components/providers/GroupDetailModeProvider.tsx
+++ b/src/components/providers/GroupDetailModeProvider.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { createGroupDetailModeStore } from '@/src/stores/groupDetail/groupDetailStore';
+import type { GroupDetailModeStoreApi, GroupDetailModeStoreProviderProps } from '@/types/groupTypes';
+import { createContext, useRef } from 'react';
+
+export const GroupDetailModeStoreContext = createContext<GroupDetailModeStoreApi | undefined>(undefined);
+
+export const GroupDetailModeProvider = ({ children, ...props }: GroupDetailModeStoreProviderProps) => {
+  const storeRef = useRef<GroupDetailModeStoreApi>();
+
+  if (!storeRef.current) {
+    storeRef.current = createGroupDetailModeStore(props);
+  }
+
+  return (
+    <GroupDetailModeStoreContext.Provider value={storeRef.current}>{children}</GroupDetailModeStoreContext.Provider>
+  );
+};

--- a/src/components/providers/GroupDetailModeProvider.tsx
+++ b/src/components/providers/GroupDetailModeProvider.tsx
@@ -1,16 +1,20 @@
 'use client';
 
 import { createGroupDetailModeStore } from '@/src/stores/groupDetail/groupDetailStore';
-import type { GroupDetailModeStoreApi, GroupDetailModeStoreProviderProps } from '@/types/groupTypes';
+import type { GroupDetailModeStoreApi } from '@/types/groupTypes';
 import { createContext, useRef } from 'react';
 
 export const GroupDetailModeStoreContext = createContext<GroupDetailModeStoreApi | undefined>(undefined);
 
-export const GroupDetailModeProvider = ({ children, ...props }: GroupDetailModeStoreProviderProps) => {
+type GroupDetailModeStoreProviderProps = {
+  children: React.ReactNode;
+};
+
+export const GroupDetailModeProvider = ({ children }: GroupDetailModeStoreProviderProps) => {
   const storeRef = useRef<GroupDetailModeStoreApi>();
 
   if (!storeRef.current) {
-    storeRef.current = createGroupDetailModeStore(props);
+    storeRef.current = createGroupDetailModeStore();
   }
 
   return (

--- a/src/hooks/groupDetail/useGroupDetailModeStore.ts
+++ b/src/hooks/groupDetail/useGroupDetailModeStore.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { GroupDetailModeStoreContext } from '@/components/providers/GroupDetailModeProvider';
+import type { GroupDetailModeStore } from '@/types/groupTypes';
+import { useContext } from 'react';
+import { useStore } from 'zustand';
+
+export const useGroupDetailModeStore = <T>(selector: (store: GroupDetailModeStore) => T): T => {
+  const groupDetailModeStoreContext = useContext(GroupDetailModeStoreContext);
+
+  if (!groupDetailModeStoreContext) {
+    throw new Error(`스토어가 비었습니다.`);
+  }
+
+  return useStore(groupDetailModeStoreContext, selector);
+};

--- a/src/hooks/groupDetail/useGroupDetailModeStore.ts
+++ b/src/hooks/groupDetail/useGroupDetailModeStore.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import { GroupDetailModeStoreContext } from '@/components/providers/GroupDetailModeProvider';
 import type { GroupDetailModeStore } from '@/types/groupTypes';
 import { useContext } from 'react';

--- a/src/hooks/queries/post/useGroupPostsQuery.ts
+++ b/src/hooks/queries/post/useGroupPostsQuery.ts
@@ -1,16 +1,31 @@
 import queryKeys from '../queryKeys';
 import { getPostsImagesPerGroup, getPostsCoverImagesPerGroup } from '@/services/server-action/postAction';
-import { useInfiniteQuery, useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 
 /** 그룹 게시물들의 이미지들 요청 쿼리 */
 export const getGroupPostsImagesQuery = (groupId: string) => {
   return useInfiniteQuery({
     queryKey: queryKeys.group.postsImages(groupId),
     queryFn: ({ queryKey, pageParam }) => getPostsImagesPerGroup({ queryKey, pageParam }),
-    initialPageParam: 0,
+    initialPageParam: 1,
     getNextPageParam: (lastPage, allPages, lastPageParam) =>
       !!lastPage.length && lastPage.length === 15 ? lastPageParam + 1 : null,
   });
+};
+
+/** 게시물 이미지 요청 prefetch */
+export const getGroupPostsImagesPrefetchQuery = (groupId: string) => {
+  const queryClient = useQueryClient();
+
+  const prefetchPostsImages = async () => {
+    await queryClient.prefetchInfiniteQuery({
+      queryKey: queryKeys.group.postsImages(groupId),
+      queryFn: ({ queryKey, pageParam }) => getPostsImagesPerGroup({ queryKey, pageParam }),
+      initialPageParam: 0,
+    });
+  };
+
+  return prefetchPostsImages;
 };
 
 /** 그룹 게시물들의 대표 이미지들 요청 쿼리 */

--- a/src/stores/groupDetail/groupDetailStore.ts
+++ b/src/stores/groupDetail/groupDetailStore.ts
@@ -1,11 +1,11 @@
 import { GroupDetailMode, type GroupDetailModeState, type GroupDetailModeStore } from '@/types/groupTypes';
 import { createStore } from 'zustand/vanilla';
 
-export const defaultInitState: GroupDetailModeState = {
+const initState: GroupDetailModeState = {
   mode: GroupDetailMode.map,
 };
 
-export const createGroupDetailModeStore = (initState: GroupDetailModeState = defaultInitState) => {
+export const createGroupDetailModeStore = () => {
   return createStore<GroupDetailModeStore>()((set) => ({
     ...initState,
     toMap: () => set(() => ({ mode: GroupDetailMode.map })),

--- a/src/stores/groupDetail/groupDetailStore.ts
+++ b/src/stores/groupDetail/groupDetailStore.ts
@@ -1,0 +1,15 @@
+import { GroupDetailMode, type GroupDetailModeState, type GroupDetailModeStore } from '@/types/groupTypes';
+import { createStore } from 'zustand/vanilla';
+
+export const defaultInitState: GroupDetailModeState = {
+  mode: GroupDetailMode.map,
+};
+
+export const createGroupDetailModeStore = (initState: GroupDetailModeState = defaultInitState) => {
+  return createStore<GroupDetailModeStore>()((set) => ({
+    ...initState,
+    toMap: () => set(() => ({ mode: GroupDetailMode.map })),
+    toAlbum: () => set(() => ({ mode: GroupDetailMode.album })),
+    toMember: () => set(() => ({ mode: GroupDetailMode.member })),
+  }));
+};

--- a/src/types/groupTypes.ts
+++ b/src/types/groupTypes.ts
@@ -1,3 +1,5 @@
+import type { createGroupDetailModeStore } from '@/stores/groupDetail/groupDetailStore';
+
 export type GroupObjType = {
   group_id: string;
   group_title: string;
@@ -50,3 +52,19 @@ export enum GroupDetailMode {
   album = 'album',
   member = 'member',
 }
+
+export type GroupDetailModeState = {
+  mode: GroupDetailMode;
+};
+
+export type GroupDetailModeActions = {
+  toMap: () => void;
+  toAlbum: () => void;
+  toMember: () => void;
+};
+
+export type GroupDetailModeStore = GroupDetailModeState & GroupDetailModeActions;
+
+export type GroupDetailModeStoreApi = ReturnType<typeof createGroupDetailModeStore>;
+
+export type GroupDetailModeStoreProviderProps = React.PropsWithChildren<GroupDetailModeState>;

--- a/src/types/groupTypes.ts
+++ b/src/types/groupTypes.ts
@@ -66,5 +66,3 @@ export type GroupDetailModeActions = {
 export type GroupDetailModeStore = GroupDetailModeState & GroupDetailModeActions;
 
 export type GroupDetailModeStoreApi = ReturnType<typeof createGroupDetailModeStore>;
-
-export type GroupDetailModeStoreProviderProps = React.PropsWithChildren<GroupDetailModeState>;


### PR DESCRIPTION
## 📝작업 내용

- 그룹 상세페이지에 zustand를 적용했습니다.
- 그룹 앨범 버튼 마우스 호버 시 프리페치 적용했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
