### PR TITLE
refactor: grouplist prefetch 병렬실행

### DIFF
--- a/src/app/grouplist/layout.tsx
+++ b/src/app/grouplist/layout.tsx
@@ -15,23 +15,24 @@ type Props = Readonly<{ children: React.ReactNode }>;
 
 const GroupListLayout = async ({ children }: Props) => {
   const queryClient = new QueryClient();
-  await queryClient.prefetchQuery({
-    queryKey: queryKeys.group.groupRandomPosts(),
-    queryFn: () => {
-      const a = getRandomPosts();
-      return a;
-    },
-  });
-
-  await queryClient.prefetchInfiniteQuery({
-    queryKey: queryKeys.group.groupList(),
-    queryFn: ({ pageParam = 1 }) => {
-      const a = getInfiniteGroupData({ pageParam });
-      return a;
-    },
-    retry: 0,
-    initialPageParam: 0,
-  });
+  await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: queryKeys.group.groupRandomPosts(),
+      queryFn: () => {
+        const a = getRandomPosts();
+        return a;
+      },
+    }),
+    queryClient.prefetchInfiniteQuery({
+      queryKey: queryKeys.group.groupList(),
+      queryFn: ({ pageParam = 1 }) => {
+        const a = getInfiniteGroupData({ pageParam });
+        return a;
+      },
+      retry: 0,
+      initialPageParam: 0,
+    }),
+  ]);
 
   return (
     <>


### PR DESCRIPTION
## 📝작업 내용

> prefetchQuery Promise.all 사용하여 병렬요청
> 그룹리스트 길이에 따라 랜덤이미지가 결정되는 부분이 있어 promise.all사용하였습니다.