### PR TITLE
[Fix] 게시물 위치정보 없을 때 폴리라인 대응

### DIFF
--- a/src/components/map/GroupMap.tsx
+++ b/src/components/map/GroupMap.tsx
@@ -135,7 +135,7 @@ const GroupMap = ({ groupId, desktop, point }: Props) => {
             }}
           >
             {postsCoverImages.map(({ post_id, post_image_url, post_lat, post_lng }) => {
-              polyline.push({ lat: post_lat, lng: post_lng });
+              post_lat && post_lng && polyline.push({ lat: post_lat, lng: post_lng });
               return (
                 <MapMarker
                   key={post_image_url}


### PR DESCRIPTION
## 📌 작업 사항

- 게시물 위치정보 없을 때 폴리라인 대응
- 

## 📋 체크 리스트

- [ ] 
- [ ] 

## 💬 기타

- 
- 